### PR TITLE
Remove Infinispan dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,12 +166,6 @@
 			<scope>provided</scope>
 		</dependency>
 		
-		<dependency>
-			<groupId>org.infinispan</groupId>
-			<artifactId>infinispan-core</artifactId>
-			<version>5.1.4.FINAL</version>
-		</dependency>
-		
 		<!-- Spring can used by MagentoSoapClient, but must be provided separately -->
         <dependency>
             <groupId>org.springframework</groupId>


### PR DESCRIPTION
Hello

The infinispan dependency of Magja caused some comflicts in the ERP software I'm integrating Magento (using Magja) into.
Because Magja uses Infinispan as a normal cache and does not use infinispan advanced capabilities, I think the Guava Cache object is much more suitable. I've replaced the one instance were infinispan was used with a Guava cache.

Please review changes and pull if you think they are sensible
