### PR TITLE
Fix SalesOrder Filter and make more generic to reuse for 'sales_order_shipment.list'

### DIFF
--- a/src/main/java/com/google/code/magja/model/order/Filter.java
+++ b/src/main/java/com/google/code/magja/model/order/Filter.java
@@ -7,25 +7,24 @@ package com.google.code.magja.model.order;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-public class OrderFilter implements Serializable {
+public class Filter implements Serializable {
 
 	private static final long serialVersionUID=-3928174333216515603L;
 
-	private List<OrderFilterItem> items = new ArrayList<OrderFilterItem>();
+	private List<FilterItem> items = new ArrayList<FilterItem>();
 	
 	public Object serializeToApi() {
-		
+
 		// Map each property to it's parameter map
 		Map<String, Map<String, String>> propertyMaps = new HashMap<String, Map<String, String>>();
-		
-		for (OrderFilterItem item : items) {
-			
+
+		for (FilterItem item : getItems()) {
+
 			String property = item.getProperty();
-			
+
 			// If we have this property already, add to the existing paramMap
 			if (propertyMaps.get(property) != null) {
 				propertyMaps.get(property).put(item.getOperator(), item.getValue());
@@ -35,33 +34,20 @@ public class OrderFilter implements Serializable {
 				propertyMaps.put(property, params);
 			}
 		}
-
-		// output in the required format, a list of maps [property -> [paramMap]]
-		List<Map<String, Map<String, String>>> result = 
-				new LinkedList<Map<String,Map<String,String>>>();
-		
-		Map<String, Map<String, String>> newMap;
-		
-		for (String property : propertyMaps.keySet()) {
-			newMap = new HashMap<String, Map<String,String>>();
-			newMap.put(property, propertyMaps.get(property));
-			result.add(newMap);
-		}
-		
-		return result;
+		return propertyMaps;
 	}
 
 	/**
 	 * @return the items
 	 */
-	public List<OrderFilterItem> getItems() {
+	public List<FilterItem> getItems() {
 		return items;
 	}
 
 	/**
 	 * @param items the items to set
 	 */
-	public void setItems(List<OrderFilterItem> items) {
+	public void setItems(List<FilterItem> items) {
 		this.items = items;
 	}
 

--- a/src/main/java/com/google/code/magja/model/order/FilterItem.java
+++ b/src/main/java/com/google/code/magja/model/order/FilterItem.java
@@ -6,7 +6,7 @@ package com.google.code.magja.model.order;
 
 import java.io.Serializable;
 
-public class OrderFilterItem implements Serializable {
+public class FilterItem implements Serializable {
 
 	private static final long serialVersionUID=7897091919944931829L;
 
@@ -16,7 +16,7 @@ public class OrderFilterItem implements Serializable {
 
 	private String value;
 
-	public OrderFilterItem(String property, String operator, String value) {
+	public FilterItem(String property, String operator, String value) {
 		this.property = property;
 		this.operator = operator;
 		this.value = value;
@@ -90,7 +90,7 @@ public class OrderFilterItem implements Serializable {
 			return false;
 		if (getClass() != obj.getClass())
 			return false;
-		OrderFilterItem other = (OrderFilterItem) obj;
+		FilterItem other = (FilterItem) obj;
 		if (operator == null) {
 			if (other.operator != null)
 				return false;
@@ -114,7 +114,7 @@ public class OrderFilterItem implements Serializable {
 	 */
 	@Override
 	public String toString() {
-		return "OrderFilterItem [operator=" + operator + ", property="
+		return "FilterItem [operator=" + operator + ", property="
 				+ property + ", value=" + value + "]";
 	}
 

--- a/src/main/java/com/google/code/magja/service/order/OrderRemoteService.java
+++ b/src/main/java/com/google/code/magja/service/order/OrderRemoteService.java
@@ -4,8 +4,8 @@
  */
 package com.google.code.magja.service.order;
 
+import com.google.code.magja.model.order.Filter;
 import com.google.code.magja.model.order.Order;
-import com.google.code.magja.model.order.OrderFilter;
 import com.google.code.magja.model.order.OrderForm;
 import com.google.code.magja.service.GeneralService;
 import com.google.code.magja.service.ServiceException;
@@ -14,7 +14,7 @@ import java.util.List;
 
 public interface OrderRemoteService extends GeneralService<Order> {
 
-    public abstract List<Order> list(OrderFilter filter) throws ServiceException;
+    public abstract List<Order> list(Filter filter) throws ServiceException;
 
     public abstract Order getById(Integer id) throws ServiceException;
 

--- a/src/main/java/com/google/code/magja/service/order/OrderRemoteServiceImpl.java
+++ b/src/main/java/com/google/code/magja/service/order/OrderRemoteServiceImpl.java
@@ -5,7 +5,6 @@
 package com.google.code.magja.service.order;
 
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -242,10 +241,10 @@ public class OrderRemoteServiceImpl extends GeneralServiceImpl<Order> implements
       *
       * @see
       * com.google.code.magja.service.order.OrderRemoteService#list(com.google.code.magja
-      * .model.order.OrderFilter)
+      * .model.order.Filter)
       */
     @Override
-    public List<Order> list(OrderFilter filter) throws ServiceException {
+    public List<Order> list(Filter filter) throws ServiceException {
 
         List<Order> results = new ArrayList<Order>();
 

--- a/src/main/java/com/google/code/magja/service/order/ShipmentRemoteService.java
+++ b/src/main/java/com/google/code/magja/service/order/ShipmentRemoteService.java
@@ -7,6 +7,7 @@ package com.google.code.magja.service.order;
 import java.util.List;
 import java.util.Map;
 
+import com.google.code.magja.model.order.Filter;
 import com.google.code.magja.model.order.Shipment;
 import com.google.code.magja.model.order.ShipmentTrack;
 import com.google.code.magja.service.GeneralService;
@@ -14,7 +15,7 @@ import com.google.code.magja.service.ServiceException;
 
 public interface ShipmentRemoteService extends GeneralService<Shipment> {
 
-	public abstract List<Shipment> list(String filter) throws ServiceException;
+	public abstract List<Shipment> list(Filter filter) throws ServiceException;
 
 	public abstract Shipment getById(Integer id) throws ServiceException;
 

--- a/src/main/java/com/google/code/magja/service/order/ShipmentRemoteServiceImpl.java
+++ b/src/main/java/com/google/code/magja/service/order/ShipmentRemoteServiceImpl.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.google.code.magja.model.order.Filter;
 import org.apache.axis2.AxisFault;
 
 import com.google.code.magja.magento.ResourcePath;
@@ -104,16 +105,26 @@ public class ShipmentRemoteServiceImpl extends GeneralServiceImpl<Shipment> impl
     }
 
     /* (non-Javadoc)
-      * @see com.google.code.magja.service.order.ShipmentRemoteService#list(java.lang.String)
+      * @see ShipmentRemoteService#list(com.google.code.magja
+      * .model.order.Filter)
       */
     @Override
-    public List<Shipment> list(String filter) throws ServiceException {
+    public List<Shipment> list(Filter filter) throws ServiceException {
 
         List<Shipment> shipments = new ArrayList<Shipment>();
 
+        if (filter != null) {
+            if (filter.getItems() != null) {
+                if (filter.getItems().isEmpty())
+                    filter = null;
+            } else
+                filter = null;
+        }
+
         List<Map<String, Object>> results = null;
         try {
-            results = soapClient.callSingle(ResourcePath.SalesOrderShipmentList, filter);
+            results = soapClient.callSingle(ResourcePath.SalesOrderShipmentList, (filter != null ? filter
+                    .serializeToApi() : ""));
         } catch (AxisFault e) {
             if (debug) e.printStackTrace();
             throw new ServiceException(e.getMessage());

--- a/src/test/java/com/google/code/magja/service/order/OrderRemoteServiceTest.java
+++ b/src/test/java/com/google/code/magja/service/order/OrderRemoteServiceTest.java
@@ -8,18 +8,13 @@ import static org.junit.Assert.fail;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.google.code.magja.model.order.*;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.code.magja.model.address.BasicAddress;
-import com.google.code.magja.model.order.Order;
-import com.google.code.magja.model.order.OrderFilter;
-import com.google.code.magja.model.order.OrderFilterItem;
-import com.google.code.magja.model.order.OrderForm;
-import com.google.code.magja.model.order.OrderFormItem;
-import com.google.code.magja.model.order.OrderItem;
 import com.google.code.magja.service.RemoteServiceFactory;
 import com.google.code.magja.service.ServiceException;
 import com.google.common.collect.ImmutableList;
@@ -123,7 +118,7 @@ public class OrderRemoteServiceTest {
 	}
 
 	/**
-	 * Test method for {@link com.google.code.magja.service.order.OrderRemoteServiceImpl#list(com.google.code.magja.model.order.OrderFilter)}.
+	 * Test method for {@link com.google.code.magja.service.order.OrderRemoteServiceImpl#list(com.google.code.magja.model.order.Filter)}.
 	 */
 	@Test
 	public void testList() {
@@ -135,9 +130,9 @@ public class OrderRemoteServiceTest {
 
 			// TODO: is not working tha find with filter
 			// make sure to have a order with billing_name = Joao da Silva
-			OrderFilter filter = new OrderFilter();
-			filter.getItems().add(new OrderFilterItem("billing_name", "like", "%Silva%"));
-			//filter.getItems().add(new OrderFilterItem("billing_lastname", "=", "Martins"));
+			Filter filter = new Filter();
+			filter.getItems().add(new FilterItem("billing_name", "like", "%Silva%"));
+			//filter.getItems().add(new FilterItem("billing_lastname", "=", "Martins"));
 
 			List<Order> filtered = service.list(filter);
 			for (Order order : filtered)

--- a/src/test/java/com/google/code/magja/service/order/ShipmentRemoteServiceTest.java
+++ b/src/test/java/com/google/code/magja/service/order/ShipmentRemoteServiceTest.java
@@ -13,6 +13,7 @@ import com.google.code.magja.model.order.ShipmentItem;
 import com.google.code.magja.model.order.ShipmentTrack;
 import com.google.code.magja.service.RemoteServiceFactory;
 import com.google.code.magja.service.ServiceException;
+import com.google.code.magja.model.order.Filter;
 
 /**
  * @author andre
@@ -66,7 +67,7 @@ public class ShipmentRemoteServiceTest {
 	}
 
 	/**
-	 * Test method for {@link com.google.code.magja.service.order.ShipmentRemoteServiceImpl#list(java.lang.String)}.
+	 * Test method for {@link com.google.code.magja.service.order.ShipmentRemoteServiceImpl#list(Filter)}.
 	 */
 	@Test
 	public void testList() {


### PR DESCRIPTION
Hi, 

please review the changes on  `OrderFilter` / `Filter::serializeToApi` closely.

Was the filtering working before? Couldn't get it to work with the existing implementation...

Thanks
Hartmut